### PR TITLE
Rename main app type

### DIFF
--- a/.cursor/rules/minimalist-ios-guide.mdc
+++ b/.cursor/rules/minimalist-ios-guide.mdc
@@ -107,4 +107,4 @@ When building iOS interfaces, always ask:
 
 Remember: The best interface is often the one that gets out of the user's way and lets them focus on their task efficiently.
 
-How to build app to make sure changes work: xcodebuild -scheme MyFitnessApp -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' build
+How to build app to make sure changes work: xcodebuild -scheme UzoFitness -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' build

--- a/UzoFitness/Documentation/Things-to-enchace.md
+++ b/UzoFitness/Documentation/Things-to-enchace.md
@@ -64,6 +64,6 @@ Here is the complete, detailed markdown-formatted task list from your PRD:
 * Consistently run unit tests using:
 
   ```
-  xcodebuild -scheme MyFitnessApp -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' build
+  xcodebuild -scheme UzoFitness -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' build
   ```
 * Thoroughly test functionality via the Xcode simulator and TestFlight releases.

--- a/UzoFitness/UzoFitnessApp.swift
+++ b/UzoFitness/UzoFitnessApp.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import SwiftData
 
 @main
-struct MyFitnessAppApp: App {
+struct UzoFitnessApp: App {
     @StateObject private var persistence = PersistenceController.shared
 
     var body: some Scene {


### PR DESCRIPTION
## Summary
- rename main app struct `MyFitnessAppApp` to `UzoFitnessApp`
- update documentation references to use the `UzoFitness` scheme

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686667ad617c8329a3df0c64790c7107