### PR TITLE
Fix docs formatting and add docs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ UzoFitness is a modern iOS application built with Swift 5 and SwiftUI that helps
 4. [Installation](#installation)
 5. [Usage](#usage)
 6. [Project Structure](#project-structure)
-7. [Dependencies](#dependencies)
-8. [Contributing](#contributing)
-9. [Roadmap](#roadmap)
-10. [License](#license)
+7. [Documentation](#documentation)
+8. [Dependencies](#dependencies)
+9. [Contributing](#contributing)
+10. [Roadmap](#roadmap)
+11. [License](#license)
 
 ---
 
@@ -30,6 +31,7 @@ UzoFitness is a modern iOS application built with Swift 5 and SwiftUI that helps
 - **Progress Photos** – Import photos from the library or camera and view them in an adaptive `ProgressPhotoGrid` component.
 - **Apple Health Sync** – One-tap authorisation to read body-mass (kg/lb) and body-fat %.  Data is cached for offline viewing.
 - **SwiftData Persistence** – Cloud-sync-ready local storage for workouts, sessions, and user metrics.
+- **iCloud Support** – Capability is enabled; cross-device sync will arrive in a future update.
 - **Accessibility** – Dynamic Type, VoiceOver, and high-contrast colour support.
 
 ## Architecture
@@ -85,8 +87,13 @@ UzoFitness/
  ├─ Views/                     // Screens & sub-views
  ├─ Components/                // Re-usable SwiftUI views
  ├─ Services/                  // HealthKit & Photo managers
- └─ Utilities/                 // Extensions & helpers
+└─ Utilities/                 // Extensions & helpers
 ```
+
+## Documentation
+Additional guides live in the [`UzoFitness/Documentation`](UzoFitness/Documentation) directory. Start with
+[`AppComponentsOverview.md`](UzoFitness/Documentation/AppComponentsOverview.md) for a tour of the codebase and
+[`CloudKitBackImplementation.md`](UzoFitness/Documentation/CloudKitBackImplementation.md) for CloudKit sync details.
 
 ## Dependencies
 | Framework | Usage |
@@ -101,7 +108,7 @@ All dependencies are **first-party Apple frameworks**—no external package mana
 We welcome pull requests!  Please read [`CONTRIBUTING.md`](CONTRIBUTING.md) for guidelines.
 
 ## Roadmap
-- iCloud sync with App Group containers
+- CloudKit-based sync with App Group containers *(capability enabled, implementation in progress)*
 - Workout scheduling & reminders
 - Social sharing & challenges
 

--- a/UzoFitness/Documentation/AppComponentsOverview.md
+++ b/UzoFitness/Documentation/AppComponentsOverview.md
@@ -1,63 +1,63 @@
-+# UzoFitness App Components Overview
-+
-+This document provides a high-level tour of the main components in the project. It is intended for new contributors who want to understand how the pieces fit together.
-+
-+## 1. App Entry
-+
-+* **`UzoFitnessApp.swift`** – Main application entry point. It creates the shared `PersistenceController` and injects its `ModelContainer` into the root view `MainTabView`.
-+* **`MainTabView`** – Hosts the five primary screens (`LoggingView`, `LibraryView`, `HistoryView`, `ProgressView`, `SettingsView`) inside a `TabView`.
-+
-+## 2. Persistence Layer
-+
-+* **Directory:** `UzoFitness/Persistence`
-+* **Key file:** `PersistenceController.swift`
-+  * Configures the SwiftData `ModelContainer` and exposes a `ModelContext` for database operations.
-+  * Provides generic CRUD helpers (`create`, `fetch`, `delete`) and sample data generation for previews.
-+  * The singleton `PersistenceController.shared` is used throughout the app for data access.
-+
-+## 3. Domain Models
-+
-+* **Directory:** `UzoFitness/Models`
-+* Contains all persistent models and related protocols/extensions. Important files include:
-+  * `Exercise`, `WorkoutTemplate`, `DayTemplate`, `ExerciseTemplate` – Planning layer models.
-+  * `WorkoutPlan`, `WorkoutSession`, `SessionExercise`, `CompletedSet` – Execution layer models.
-+  * `PerformedExercise`, `ProgressPhoto` – Historical data and progress tracking.
-+  * `Enums.swift` – Enumerations such as `ExerciseCategory`, `Weekday`, `PhotoAngle`, and validation errors.
-+  * `Protocols.swift` – Shared model protocols like `Identified` (provides a UUID) and `Timestamped` (creation date).
-+  * Extension files under `Models/Extensions` add validation and helper methods for the core models.
-+
-+See `Models-Architecture-Summary.md` in this folder for a more detailed description of relationships between these models.
-+
-+## 4. Services
-+
-+* **Directory:** `UzoFitness/Services`
-+* **`HealthKitManager.swift`** – Handles all HealthKit read/write logic. Protocol-based abstractions allow the manager to be unit‑tested or mocked.
-+* **`PhotoService.swift`** – Manages progress‑photo capture and caching. It interacts with the photo library, file system and SwiftData via protocol‑driven dependencies.
-+
-+## 5. View Models
-+
-+* **Directory:** `UzoFitness/ViewModels`
-+* Each screen has a corresponding `ObservableObject` view model responsible for business logic and data flow:
-+  * `LoggingViewModel` – Drives workout logging, set tracking and rest timers.
-+  * `LibraryViewModel` – CRUD hub for workout templates, exercises and active plans.
-+  * `HistoryViewModel` – Loads historical workout sessions and summaries for the calendar view.
-+  * `ProgressViewModel` – Provides charts of performance trends and progress photo management.
-+  * `SettingsViewModel` – Handles permissions, backups and other app configuration settings.
-+* `ViewModelSpec.md` gives detailed specs for these view models.
-+
-+## 6. Views
-+
-+* **Directory:** `UzoFitness/Views`
-+  * `Screens/` – SwiftUI screens for each tab (`LoggingView.swift`, `LibraryView.swift`, etc.). Many have accompanying `*_PRD.md` and `*_Tasks.md` docs that outline design details and to‑dos.
-+  * `Components/` – Reusable UI pieces like charts (`MetricLineChart`, `ConsolidatedMetricChart`), photo management views and JSON import helpers.
-+* Views are intentionally kept lightweight. They delegate logic to their view models and use dependency injection for services.
-+
-+## 7. Other Resources
-+
-+* **`Assets.xcassets`** – Image and color assets used by the app.
-+* **`UzoFitness.entitlements`** – Capability settings (HealthKit, Photos, iCloud, etc.).
-+* **Tests** – Unit tests live in `UzoFitnessTests` and UI tests in `UzoFitnessUITests`.
-+
-+---
-+
-+This overview should help you navigate the repository and understand where each major piece of the application lives. For deeper dives, consult the other markdown files in this `Documentation` folder.
+# UzoFitness App Components Overview
+
+This document provides a high-level tour of the main components in the project. It is intended for new contributors who want to understand how the pieces fit together.
+
+## 1. App Entry
+
+* **`UzoFitnessApp.swift`** – Main application entry point. It creates the shared `PersistenceController` and injects its `ModelContainer` into the root view `MainTabView`.
+* **`MainTabView`** – Hosts the five primary screens (`LoggingView`, `LibraryView`, `HistoryView`, `ProgressView`, `SettingsView`) inside a `TabView`.
+
+## 2. Persistence Layer
+
+* **Directory:** `UzoFitness/Persistence`
+* **Key file:** `PersistenceController.swift`
+  * Configures the SwiftData `ModelContainer` and exposes a `ModelContext` for database operations.
+  * Provides generic CRUD helpers (`create`, `fetch`, `delete`) and sample data generation for previews.
+  * The singleton `PersistenceController.shared` is used throughout the app for data access.
+
+## 3. Domain Models
+
+* **Directory:** `UzoFitness/Models`
+* Contains all persistent models and related protocols/extensions. Important files include:
+  * `Exercise`, `WorkoutTemplate`, `DayTemplate`, `ExerciseTemplate` – Planning layer models.
+  * `WorkoutPlan`, `WorkoutSession`, `SessionExercise`, `CompletedSet` – Execution layer models.
+  * `PerformedExercise`, `ProgressPhoto` – Historical data and progress tracking.
+  * `Enums.swift` – Enumerations such as `ExerciseCategory`, `Weekday`, `PhotoAngle`, and validation errors.
+  * `Protocols.swift` – Shared model protocols like `Identified` (provides a UUID) and `Timestamped` (creation date).
+  * Extension files under `Models/Extensions` add validation and helper methods for the core models.
+
+See `Models-Architecture-Summary.md` in this folder for a more detailed description of relationships between these models.
+
+## 4. Services
+
+* **Directory:** `UzoFitness/Services`
+* **`HealthKitManager.swift`** – Handles all HealthKit read/write logic. Protocol-based abstractions allow the manager to be unit‑tested or mocked.
+* **`PhotoService.swift`** – Manages progress‑photo capture and caching. It interacts with the photo library, file system and SwiftData via protocol‑driven dependencies.
+
+## 5. View Models
+
+* **Directory:** `UzoFitness/ViewModels`
+* Each screen has a corresponding `ObservableObject` view model responsible for business logic and data flow:
+  * `LoggingViewModel` – Drives workout logging, set tracking and rest timers.
+  * `LibraryViewModel` – CRUD hub for workout templates, exercises and active plans.
+  * `HistoryViewModel` – Loads historical workout sessions and summaries for the calendar view.
+  * `ProgressViewModel` – Provides charts of performance trends and progress photo management.
+  * `SettingsViewModel` – Handles permissions, backups and other app configuration settings.
+* `ViewModelSpec.md` gives detailed specs for these view models.
+
+## 6. Views
+
+* **Directory:** `UzoFitness/Views`
+  * `Screens/` – SwiftUI screens for each tab (`LoggingView.swift`, `LibraryView.swift`, etc.). Many have accompanying `*_PRD.md` and `*_Tasks.md` docs that outline design details and to‑dos.
+  * `Components/` – Reusable UI pieces like charts (`MetricLineChart`, `ConsolidatedMetricChart`), photo management views and JSON import helpers.
+* Views are intentionally kept lightweight. They delegate logic to their view models and use dependency injection for services.
+
+## 7. Other Resources
+
+* **`Assets.xcassets`** – Image and color assets used by the app.
+* **`UzoFitness.entitlements`** – Capability settings (HealthKit, Photos, iCloud). The iCloud container is configured but sync is not yet implemented.
+* **Tests** – Unit tests live in `UzoFitnessTests` and UI tests in `UzoFitnessUITests`.
+
+---
+
+This overview should help you navigate the repository and understand where each major piece of the application lives. For deeper dives, consult the other markdown files in this `Documentation` folder.

--- a/UzoFitness/Documentation/CloudKitBackImplementation.md
+++ b/UzoFitness/Documentation/CloudKitBackImplementation.md
@@ -2,6 +2,8 @@
 
 # 1. **CloudKit Setup**
 
+> **Status**: The iCloud capability is already enabled in the project, but the actual sync implementation is still in progress.
+
 ### a. Enable CloudKit in Xcode
 - Go to your project target → **Signing & Capabilities**.
 - Add **iCloud** capability, check **CloudKit**.


### PR DESCRIPTION
## Summary
- clean up documentation formatting in `AppComponentsOverview.md`
- document additional guides in README
- mention that iCloud capability is present and sync code is coming soon

## Testing
- `xcodebuild -list -project UzoFitness.xcodeproj` *(fails: command not found)*
- `xcodebuild test -project UzoFitness.xcodeproj -scheme UzoFitness -destination 'platform=iOS Simulator,name=iPhone 8'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ad080ea3c8329abc3117a0ccd4e04